### PR TITLE
Fix invalid data was sent in case of multiple user tokens

### DIFF
--- a/lib/push_to_devices.rb
+++ b/lib/push_to_devices.rb
@@ -171,7 +171,7 @@ module PushToDevices
       #     }
       # }
       def post_notification_to_users(params = {})
-        post("users/notifications", params)
+        post("users/notifications", params.merge(params.delete(:notification_data)))
       end
 
       # POSTS to users/ to register a user for push notifications

--- a/spec/push_to_device/push_to_device_spec.rb
+++ b/spec/push_to_device/push_to_device_spec.rb
@@ -42,7 +42,7 @@ describe PushToDevices do
         android_specific_fields: {text: "android"}
       }
       PushToDevices::API.post_notification_to_users(unique_hashes: unique_hashes, notification_data: notification_data)
-      a_request(:post, "http://nowhere.com/users/notifications").with(body: {unique_hashes: unique_hashes, notification_data: notification_data}.to_json).should have_been_made
+      a_request(:post, "http://nowhere.com/users/notifications").with(body: {unique_hashes: unique_hashes}.merge(notification_data).to_json).should have_been_made
     end
   end
 


### PR DESCRIPTION
The method post_notification_to_users used a different structured payload when sending data to the server.

Currently the Push to Devices serves expects the notification data to be directly in the JSON-formatted body (not nested under a "notication_data" key).
See https://github.com/lloydmeta/push_to_devices/blob/master/app/controllers/users.rb#L93

This commit fixes this issue by using the same structure as the method for a single user token.
