### PR TITLE
Allow usage of several API objects in parallel

### DIFF
--- a/lib/push_to_devices.rb
+++ b/lib/push_to_devices.rb
@@ -20,6 +20,12 @@ module PushToDevices
 
   module API
 
+    def self.new(&block)
+      instance = dup
+      instance.configure(&block) if block
+      instance
+    end
+
     class << self
       attr_accessor :client_id, :client_secret, :user_agent, :use_ssl, :debug, :host, :port, :client_info
 

--- a/spec/push_to_device/push_to_device_spec.rb
+++ b/spec/push_to_device/push_to_device_spec.rb
@@ -59,4 +59,31 @@ describe PushToDevices do
     end
   end
 
+  describe ".new" do
+    let(:development) do
+      PushToDevices::API.new do |config|
+        config.host = "local.dev"
+        config.use_ssl = false
+      end
+    end
+
+    let(:production) do
+      api = PushToDevices::API.new
+      api.configure do |config|
+        config.host = "example.com"
+        config.use_ssl = true
+        config.port = 443
+      end
+      api
+    end
+
+    it "uses two api objects in parallel" do
+      development.get_service_info
+      a_request(:get, "http://local.dev/services/me").should have_been_made
+
+      production.get_service_info
+      a_request(:get, "https://example.com/services/me").should have_been_made
+    end
+  end
+
 end


### PR DESCRIPTION
This commit enables the usage for more than one API configuration
side by side.

Example:

``` ruby
dev = PushToDevices::API.new do |config|
  config.host = "local.dev"
  ...
end
dev.get_service_info

prod = PushToDevices::API.new
prod.configure do |config|
  config.host = "prod"
  config.use_ssl = true
  config.port = 443
  ...
end
prod.get_service_info
```

/cc @jnbt @Khalasar
